### PR TITLE
Refactor multi-profile code

### DIFF
--- a/src/dev/ukanth/ufirewall/G.java
+++ b/src/dev/ukanth/ufirewall/G.java
@@ -128,5 +128,19 @@ public class G extends android.app.Application {
 		pPrefs = ctx.getSharedPreferences(profileName, Context.MODE_PRIVATE);
 		sPrefs = ctx.getSharedPreferences("AFWallStaus" /* sic */, Context.MODE_PRIVATE);
 	}
-	
+
+	public static void reloadProfile() {
+		reloadPrefs();
+		Api.applications = null;
+	}
+
+	public static boolean setProfile(boolean newEnableMultiProfile, int newStoredPosition) {
+		if (newEnableMultiProfile == enableMultiProfile() && newStoredPosition == storedPosition()) {
+			return false;
+		}
+		enableMultiProfile(newEnableMultiProfile);
+		storedPosition(newEnableMultiProfile ? newStoredPosition : 0);
+		reloadProfile();
+		return true;
+	}
 }

--- a/src/dev/ukanth/ufirewall/MainActivity.java
+++ b/src/dev/ukanth/ufirewall/MainActivity.java
@@ -1413,11 +1413,7 @@ public class MainActivity extends SherlockListActivity implements OnCheckedChang
 
 	@Override
 	public boolean onNavigationItemSelected(int itemPosition, long itemId) {
-		
-		if (G.enableMultiProfile()) {
-			G.storedPosition(itemPosition);
-			Api.PREFS_NAME = G.profiles[itemPosition];
-			Api.applications = null;
+		if (G.enableMultiProfile() && G.setProfile(true, itemPosition)) {
 			new GetAppList().execute();
 			mSelected.setText("  |  " + mLocations[itemPosition]);
 			refreshHeader();

--- a/src/dev/ukanth/ufirewall/StartupService.java
+++ b/src/dev/ukanth/ufirewall/StartupService.java
@@ -51,30 +51,9 @@ public class StartupService extends Service {
 	public int onStartCommand(Intent intent, int flags, int startId) {
 		context = this;
 		
-		SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(getApplicationContext());
-		final boolean multimode = prefs.getBoolean("enableMultiProfile", false);
-		
 		if (Api.isEnabled(context.getApplicationContext())) {
-			if(multimode){
-				int itemPosition = prefs.getInt("storedPosition", 0);
-				switch (itemPosition) {
-				case 0:
-					Api.PREFS_NAME = "AFWallPrefs";
-					break;
-				case 1:
-					Api.PREFS_NAME = "AFWallProfile1";
-					break;
-				case 2:
-					Api.PREFS_NAME = "AFWallProfile2";
-					break;
-				case 3:
-					Api.PREFS_NAME = "AFWallProfile3";
-					break;
-				default:
-					break;
-				}
-			}
-			
+			G.reloadPrefs();
+
 			new Thread() {
 				public void run() {
 					Looper.prepare();

--- a/src/dev/ukanth/ufirewall/plugin/FireReceiver.java
+++ b/src/dev/ukanth/ufirewall/plugin/FireReceiver.java
@@ -22,6 +22,7 @@ import android.os.Message;
 import android.preference.PreferenceManager;
 import android.widget.Toast;
 import dev.ukanth.ufirewall.Api;
+import dev.ukanth.ufirewall.G;
 import dev.ukanth.ufirewall.R;
 
 /**
@@ -104,16 +105,16 @@ public final class FireReceiver extends BroadcastReceiver
 					}
         			break;
         		case 2:
-    				Api.PREFS_NAME = "AFWallPrefs";
+    				G.setProfile(multimode, 0);
     				break;
     			case 3:
-    				Api.PREFS_NAME = "AFWallProfile1";
+    				G.setProfile(multimode, 1);
     				break;
     			case 4:
-    				Api.PREFS_NAME = "AFWallProfile2";
+    				G.setProfile(multimode, 2);
     				break;
     			case 5:
-    				Api.PREFS_NAME = "AFWallProfile3";
+    				G.setProfile(multimode, 3);
     				break;
     			default:
     				break;

--- a/src/dev/ukanth/ufirewall/preferences/PreferencesActivity.java
+++ b/src/dev/ukanth/ufirewall/preferences/PreferencesActivity.java
@@ -226,23 +226,13 @@ public class PreferencesActivity extends UnifiedSherlockPreferenceActivity
 		if (key.equals("showUid") || key.equals("enableMultiProfile")
 				|| key.equals("disableIcons") || key.equals("enableVPN") || key.equals("enableLAN")
 				|| key.equals("enableRoam") || key.equals("locale") ) {
-			Api.applications = null;
-			Intent returnIntent = new Intent();
-			boolean value = sharedPreferences.getBoolean("enableMultiProfile", false);
-			if(!value){
-				SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(getApplicationContext());
-				SharedPreferences.Editor editor = prefs.edit();
-				editor.putInt("storedPosition", 0);
-				editor.commit();
+			// revert back to Default profile when disabling multi-profile support
+			if (!G.enableMultiProfile()) {
+				G.storedPosition(0);
 			}
-			//reset values of vpn profile
-			/*boolean vpnStatus = sharedPreferences.getBoolean("enableVPN", false);
-			if(!vpnStatus) {
-				
-				returnIntent.putExtra("reset", true);
-			}*/
-			
-			setResult(RESULT_OK, returnIntent);
+			G.reloadProfile();
+
+			setResult(RESULT_OK, new Intent());
 		}
 
 		if (key.equals("fixLeak")) {

--- a/src/dev/ukanth/ufirewall/widget/ToggleWidgetActivity.java
+++ b/src/dev/ukanth/ufirewall/widget/ToggleWidgetActivity.java
@@ -14,6 +14,7 @@ import android.view.View.OnClickListener;
 import android.widget.Button;
 import android.widget.Toast;
 import dev.ukanth.ufirewall.Api;
+import dev.ukanth.ufirewall.G;
 import dev.ukanth.ufirewall.R;
 
 public class ToggleWidgetActivity extends Activity implements OnClickListener {
@@ -53,16 +54,14 @@ public class ToggleWidgetActivity extends Activity implements OnClickListener {
 		profButton2.setOnClickListener(this);
 		profButton3.setOnClickListener(this);
 		
-		final SharedPreferences defaultRefs = PreferenceManager.getDefaultSharedPreferences(getApplicationContext());
-		final boolean multimode = defaultRefs.getBoolean("enableMultiProfile", false);
-		if(!multimode) {
+		if(!G.enableMultiProfile()) {
 			profButton1.setEnabled(false);
 			profButton2.setEnabled(false);
 			profButton3.setEnabled(false);
 		} else {
-			if(Api.isEnabled(getApplicationContext())){
-				int position = getProfilePosition();
-				if(position == 0){
+			if(Api.isEnabled(getApplicationContext())) {
+				int position = G.storedPosition();
+				if (position == 0) {
 					disableDefault();
 				} else {
 					disableCustom(position);	
@@ -139,25 +138,25 @@ public class ToggleWidgetActivity extends Activity implements OnClickListener {
 					
 					break;
 				case 3:
-					setProfilePosition(0);
+					G.setProfile(G.enableMultiProfile(), 0);
 					if(applyProfileRules(context,msg,toaster)) {
 						disableDefault();
 					}
 					break;
 				case 4:
-					setProfilePosition(1);
+					G.setProfile(true, 1);
 					if(applyProfileRules(context,msg,toaster)){
 						disableCustom(1);
 					}
 					break;
 				case 5:
-					setProfilePosition(2);
+					G.setProfile(true, 2);
 					if(applyProfileRules(context,msg,toaster)){
 						disableCustom(2);
 					}
 					break;
 				case 6:
-					setProfilePosition(3);
+					G.setProfile(true, 3);
 					if(applyProfileRules(context,msg,toaster)){
 						disableCustom(3);
 					}
@@ -168,15 +167,12 @@ public class ToggleWidgetActivity extends Activity implements OnClickListener {
 	}
 	
 	private void enableOthers() {
-		final SharedPreferences defaultRefs = PreferenceManager.getDefaultSharedPreferences(getApplicationContext());
-		final boolean multimode = defaultRefs.getBoolean("enableMultiProfile", false);
-		
 		runOnUiThread(new Runnable() {
 			public void run() {
 				enableButton.setEnabled(false);
 				disableButton.setEnabled(true);
 				defaultButton.setEnabled(true);
-				if(multimode){
+				if (G.enableMultiProfile()){
 					profButton1.setEnabled(true);
 					profButton2.setEnabled(true);
 					profButton3.setEnabled(true);
@@ -200,12 +196,10 @@ public class ToggleWidgetActivity extends Activity implements OnClickListener {
 	}
 	
 	private void disableDefault() {
-		final SharedPreferences defaultRefs = PreferenceManager.getDefaultSharedPreferences(getApplicationContext());
-		final boolean multimode = defaultRefs.getBoolean("enableMultiProfile", false);
 		runOnUiThread(new Runnable() {
 			public void run() {
 				defaultButton.setEnabled(false);
-				if(multimode){
+				if (G.enableMultiProfile()) {
 					profButton1.setEnabled(true);
 					profButton2.setEnabled(true);
 					profButton3.setEnabled(true);
@@ -266,38 +260,6 @@ public class ToggleWidgetActivity extends Activity implements OnClickListener {
 			toaster.sendMessage(msg);
 		}
 		return success;
-	}
-	
-	private void setProfilePosition(int position){
-		SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(getApplicationContext());
-		final boolean multimode = prefs.getBoolean("enableMultiProfile", false);
-		Editor editor = prefs.edit();
-		if(multimode){
-			switch (position) {
-			case 0:
-				Api.PREFS_NAME = "AFWallPrefs";			
-				break;
-			case 1:
-				Api.PREFS_NAME = "AFWallProfile1";
-				break;
-			case 2:
-				Api.PREFS_NAME = "AFWallProfile2";
-				break;
-			case 3:
-				Api.PREFS_NAME = "AFWallProfile3";
-				break;
-			default:
-				break;
-			}
-		}
-		editor.putInt("storedPosition", position);
-		editor.commit();
-		
-	}
-	
-	private int getProfilePosition(){
-		SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(getApplicationContext());
-		return prefs.getInt("storedPosition", 0);
 	}
 }
 


### PR DESCRIPTION
Consolidate the redundant preference checks and switch statements into
G.java.  Revert back to the Default profile when multi-profile is
disabled.  Fix a couple of instances where the active profile UID lists
got out of sync with the current profile selection.
