### PR TITLE
RootShell: Fix missing BUSY state transition

### DIFF
--- a/src/dev/ukanth/ufirewall/RootShell.java
+++ b/src/dev/ukanth/ufirewall/RootShell.java
@@ -209,6 +209,7 @@ public class RootShell {
 				complete(state, EXIT_NO_ROOT_ACCESS);
 				continue;
 			} else if (rootState == STATE_READY) {
+				rootState = STATE_BUSY;
 				submitNextCommand(state);
 			}
 		} while (false);


### PR DESCRIPTION
Reported in bug #167:

> On CM7.2, Rules are not applied on boot and when I tried to view the rules, it was showing the previous rules. The issue might be because of sdcard scanning at the beginning. We need to check this.

I was able to reproduce this; it showed up on maybe one out of every 5-10 boots on my Nexus S.  The issue is that we're missing a state transition in RootShell.java, so if the relative timing of the BOOT_COMPLETED intent, the CONNECTIVITY CHANGE intent, and the wifi IP change is just right, RootShell will try to run two command lists in parallel instead of sequentially.

In <a href="http://pastebin.com/2vNTETQ9">this log</a> you can see a "-F afwall-3g" from the fastApply sequence pop up right in the middle of a regular applyIptablesRulesImpl() sequence.  If this happens before the "afwall-3g" chain is created, the user will see an error notification; if not, it may cause incorrect rules to be applied.

My proposed fix survived 20 reboots on the same CM7.2 device.  It was lightly tested on JB as well.
