### PR TITLE
Api: Default to builtin ip6tables binary

### DIFF
--- a/src/dev/ukanth/ufirewall/Api.java
+++ b/src/dev/ukanth/ufirewall/Api.java
@@ -213,8 +213,10 @@ public final class Api {
 		} else if (pref.equals("builtin")) {
 			builtin = true;
 		} else {
-			// auto setting: ICS+ devices are mostly expected to have good iptables binaries
-			if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.ICE_CREAM_SANDWICH) {
+			// auto setting:
+			// IPv4 iptables on ICS+ devices is mostly sane, so we'll use it by default
+			// IPv6 ip6tables can return the wrong exit status (bug #215) so default to our fixed version
+			if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.ICE_CREAM_SANDWICH && !setv6) {
 				builtin = false;
 			} else {
 				builtin = true;


### PR DESCRIPTION
As documented in bug #215, ip6tables from AOSP uses an incorrect exit
status code if the kernel returns EAGAIN, making it impossible to
differentiate between a hard failure and a transient failure.  Users on
v1.2.7 are still running into this because the system ip6tables binary
is still used by default.

So, in the default configuration ("auto" mode), let's switch over to our
builtin ip6tables binary.  Users can still force the use of all system
binaries, or all builtin binaries, through Preferences.
