### PR TITLE
Build afwall inside AOSP

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -28,10 +28,20 @@ include $(CLEAR_VARS)
 
 LOCAL_MODULE_TAGS := optional
 
-LOCAL_SRC_FILES := $(call all-java-files-under, src)
+LOCAL_SRC_FILES := $(call all-java-files-under, src) \
+LOCAL_SRC_FILES += $(call all-java-files-under, actionbarsherlock/src)
+LOCAL_SRC_FILES += $(call all-java-files-under, android-lockpattern/src)
+
+LOCAL_RESOURCE_DIR += $(LOCAL_PATH)/res
+LOCAL_RESOURCE_DIR += $(LOCAL_PATH)/actionbarsherlock/res
+LOCAL_RESOURCE_DIR += $(LOCAL_PATH)/android-lockpattern/res
 
 LOCAL_STATIC_JAVA_LIBRARIES := \
-    android-support-v4
+    android-support-v4 \
+    ActionBarSherlock
+
+LOCAL_AAPT_FLAGS := --auto-add-overlay \
+    --extra-packages com.actionbarsherlock:group.pals.android.lib.ui.lockpattern
 
 LOCAL_PACKAGE_NAME := afwall
 LOCAL_CERTIFICATE := platform

--- a/Android.mk
+++ b/Android.mk
@@ -30,6 +30,9 @@ LOCAL_MODULE_TAGS := optional
 
 LOCAL_SRC_FILES := $(call all-java-files-under, src)
 
+LOCAL_STATIC_JAVA_LIBRARIES := \
+    android-support-v4
+
 LOCAL_PACKAGE_NAME := afwall
 LOCAL_CERTIFICATE := platform
 

--- a/res/layout/dialog_color_picker.xml
+++ b/res/layout/dialog_color_picker.xml
@@ -33,8 +33,8 @@
 	
 	<TextView
 		android:layout_width="wrap_content"
-		android:layout_height="wrap_content"	
-		android:text="Press on Color to apply"
+		android:layout_height="wrap_content"
+		android:text="@string/apply_color"
 		android:gravity="left"
 		android:layout_marginLeft="6dp"
 		android:layout_marginRight="6dp"

--- a/res/layout/rules.xml
+++ b/res/layout/rules.xml
@@ -11,7 +11,6 @@
             android:layout_height="wrap_content"
             android:paddingLeft="10dp"
             android:paddingRight="10dp"
-            android:paddingTop="?actionBarSize"
             android:orientation="vertical">
             <!-- <TextView
                 android:layout_width="fill_parent"

--- a/res/menu/menu_bar.xml
+++ b/res/menu/menu_bar.xml
@@ -3,11 +3,9 @@
 
     <item
         android:id="@+id/menu_search"
-        android:icon="@drawable/abs__ic_search"
         android:showAsAction="always|collapseActionView"/>
     <item
         android:id="@+id/menu_list_item"
-        android:icon="@drawable/abs__ic_menu_moreoverflow_normal_holo_dark"
         android:showAsAction="always"
         android:title="">
         <menu>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -284,5 +284,8 @@
      <string name="select_all">Do you want to select all ?</string>
      <string name="reverse_all">Do you want to reverse select all ?</string>
      <string name="unselect_all">Do you want to unselect all ?</string>
-     
+
+     <!-- Strings that need to be localized in order to build inside AOSP -->
+     <string name="apply_color">Press on Color to apply</string>
+     <string name="arrow">→</string>
 </resources>

--- a/res/xml/unified_preferences_headers.xml
+++ b/res/xml/unified_preferences_headers.xml
@@ -3,25 +3,20 @@
 
     <header
         unified:fragment="dev.ukanth.ufirewall.preferences.PreferencesActivity$GeneralPreferenceFragment"
-        unified:preferenceRes="@xml/ui_preferences"
-        unified:title="@string/ui_prefs_title" />
+        unified:preferenceRes="@xml/ui_preferences" />
     <header
         unified:fragment="dev.ukanth.ufirewall.preferences.PreferencesActivity$SecPreferenceFragment"
-        unified:preferenceRes="@xml/security_preferences"
-        unified:title="@string/sec_prefs_title" />
+        unified:preferenceRes="@xml/security_preferences" />
     <header
         unified:fragment="dev.ukanth.ufirewall.preferences.PreferencesActivity$ExpPreferenceFragment"
-        unified:preferenceRes="@xml/experimental_preferences"
-        unified:title="@string/exp_prefs_title" />
-    
+        unified:preferenceRes="@xml/experimental_preferences" />
+
     <header
         unified:fragment="dev.ukanth.ufirewall.preferences.PreferencesActivity$MultiProfilePreferenceFragment"
-        unified:preferenceRes="@xml/profiles_preferences"
-        unified:title="@string/mp_prefs_title" />
-    
+        unified:preferenceRes="@xml/profiles_preferences" />
+
     <header
         unified:fragment="dev.ukanth.ufirewall.preferences.PreferencesActivity$CustomBinaryPreferenceFragment"
-        unified:preferenceRes="@xml/ui_custom_preferences"
-        unified:title="Binaries" />
-    
+        unified:preferenceRes="@xml/ui_custom_preferences" />
+
 </preference-headers>


### PR DESCRIPTION
(NOT FINISHED YET)

afwall still cannot be build inside an AOSP tree. This is required if you want to directly include afwall in a clean way into a ROM. (Droidwall supported this)
There are several reasons why this is not working, some I tried to already fix in this PR.

fix provided (but not tested):

- All strings need to be localized
- There are some unknown resources when building inside AOSP
- Additional settings required in `Android.mk`

not fixed:

- Include ActionBarSherlock in a way that does not require a submodule (not sure how this is done cleanly), or be independend from it

Currently, after manually checking out the submodule, the build fails with the following message:

```
make: *** No rule to make target `/home/vagrant/cyanogen/out/target/common/obj/JAVA_LIBRARIES/ActionBarSherlock_intermediates/javalib.jar', needed by `/home/vagrant/cyanogen/out/target/common/obj/APPS/afwall_intermediates/classes-full-debug.jar'.  Stop.
```

Any thoughts or additional ideas?