### PR TITLE
add "drm" special Android account

### DIFF
--- a/aFWall/src/main/java/dev/ukanth/ufirewall/Api.java
+++ b/aFWall/src/main/java/dev/ukanth/ufirewall/Api.java
@@ -1115,11 +1115,11 @@ public final class Api {
 				//specialData.add(new PackageInfoData(SPECIAL_UID_DNSPROXY, ctx.getString(R.string.dnsproxy_item), "dev.afwall.special.dnsproxy"));
 				specialData.add(new PackageInfoData(SPECIAL_UID_NTP, ctx.getString(R.string.ntp_item), "dev.afwall.special.ntp"));
 				specialData.add(new PackageInfoData("root", ctx.getString(R.string.root_item), "dev.afwall.special.root"));
-				specialData.add(new PackageInfoData("adb", "ADB (Android Debug Bridge)", "dev.afwall.special.adb"));
-				specialData.add(new PackageInfoData("media", "Media server", "dev.afwall.special.media"));
-				specialData.add(new PackageInfoData("vpn", "VPN networking", "dev.afwall.special.vpn"));
-				specialData.add(new PackageInfoData("gps", "GPS", "dev.afwall.special.gps"));
-				specialData.add(new PackageInfoData("shell", "Linux shell", "dev.afwall.special.shell"));
+				specialData.add(new PackageInfoData("adb", ctx.getString(R.string.adb_item), "dev.afwall.special.adb"));
+				specialData.add(new PackageInfoData("media", ctx.getString(R.string.media_item), "dev.afwall.special.media"));
+				specialData.add(new PackageInfoData("vpn", ctx.getString(R.string.vpn_item), "dev.afwall.special.vpn"));
+				specialData.add(new PackageInfoData("gps", ctx.getString(R.string.gps_item), "dev.afwall.special.gps"));
+				specialData.add(new PackageInfoData("shell", ctx.getString(R.string.shell_item), "dev.afwall.special.shell"));
 				
 				if(specialApps == null) {
 					specialApps = new HashMap<String, Integer>(); 

--- a/aFWall/src/main/java/dev/ukanth/ufirewall/Api.java
+++ b/aFWall/src/main/java/dev/ukanth/ufirewall/Api.java
@@ -218,6 +218,7 @@ public final class Api {
 		"adb",
 		"media",
 		"vpn",
+		"drm",
 		"gps",
 		"shell",
 	};

--- a/aFWall/src/main/java/dev/ukanth/ufirewall/Api.java
+++ b/aFWall/src/main/java/dev/ukanth/ufirewall/Api.java
@@ -1115,11 +1115,11 @@ public final class Api {
 				//specialData.add(new PackageInfoData(SPECIAL_UID_DNSPROXY, ctx.getString(R.string.dnsproxy_item), "dev.afwall.special.dnsproxy"));
 				specialData.add(new PackageInfoData(SPECIAL_UID_NTP, ctx.getString(R.string.ntp_item), "dev.afwall.special.ntp"));
 				specialData.add(new PackageInfoData("root", ctx.getString(R.string.root_item), "dev.afwall.special.root"));
+				specialData.add(new PackageInfoData("adb", "ADB (Android Debug Bridge)", "dev.afwall.special.adb"));
 				specialData.add(new PackageInfoData("media", "Media server", "dev.afwall.special.media"));
 				specialData.add(new PackageInfoData("vpn", "VPN networking", "dev.afwall.special.vpn"));
-				specialData.add(new PackageInfoData("shell", "Linux shell", "dev.afwall.special.shell"));
 				specialData.add(new PackageInfoData("gps", "GPS", "dev.afwall.special.gps"));
-				specialData.add(new PackageInfoData("adb", "ADB (Android Debug Bridge)", "dev.afwall.special.adb"));
+				specialData.add(new PackageInfoData("shell", "Linux shell", "dev.afwall.special.shell"));
 				
 				if(specialApps == null) {
 					specialApps = new HashMap<String, Integer>(); 
@@ -2293,11 +2293,11 @@ public final class Api {
 			//specialApps.put("dev.afwall.special.dnsproxy",SPECIAL_UID_DNSPROXY);
 			specialApps.put("dev.afwall.special.ntp",SPECIAL_UID_NTP);
 			specialApps.put("dev.afwall.special.root",android.os.Process.getUidForName("root"));
+			specialApps.put("dev.afwall.special.adb",android.os.Process.getUidForName("adb"));
 			specialApps.put("dev.afwall.special.media",android.os.Process.getUidForName("media"));
 			specialApps.put("dev.afwall.special.vpn",android.os.Process.getUidForName("vpn"));
-			specialApps.put("dev.afwall.special.shell",android.os.Process.getUidForName("shell"));
 			specialApps.put("dev.afwall.special.gps",android.os.Process.getUidForName("gps"));
-			specialApps.put("dev.afwall.special.adb",android.os.Process.getUidForName("adb"));	
+			specialApps.put("dev.afwall.special.shell",android.os.Process.getUidForName("shell"));
 		}
 	}
 	

--- a/aFWall/src/main/res/values/strings.xml
+++ b/aFWall/src/main/res/values/strings.xml
@@ -28,11 +28,11 @@
     <string name="dnsproxy_item">(DNS proxy) - DNS lookups via netd</string>
     <string name="ntp_item">(NTP) - Internet time servers</string>
     <string name="root_item">(root) - Applications running as root</string>
-    <string name="adb_item">ADB (Android Debug Bridge)</string>
-    <string name="media_item">Media server</string>
-    <string name="vpn_item">VPN networking</string>
-    <string name="gps_item">GPS</string>
-    <string name="shell_item">Linux shell</string>
+    <string name="adb_item">(adb) - ADB (Android Debug Bridge)</string>
+    <string name="media_item">(media) - Media server</string>
+    <string name="vpn_item">(vpn) - VPN networking</string>
+    <string name="gps_item">(gps) - GPS</string>
+    <string name="shell_item">(shell) - Linux shell</string>
     <!-- <string name="operation_timeout">Operation timed out</string> -->
     <string name="fw_enabled">Enable Firewall</string>
     <string name="fw_disabled">Disable Firewall</string>

--- a/aFWall/src/main/res/values/strings.xml
+++ b/aFWall/src/main/res/values/strings.xml
@@ -31,6 +31,7 @@
     <string name="adb_item">(adb) - ADB (Android Debug Bridge)</string>
     <string name="media_item">(media) - Media server</string>
     <string name="vpn_item">(vpn) - VPN networking</string>
+    <string name="drm_item">(drm) - Digital Rights Management service</string>
     <string name="gps_item">(gps) - GPS</string>
     <string name="shell_item">(shell) - Linux shell</string>
     <!-- <string name="operation_timeout">Operation timed out</string> -->

--- a/aFWall/src/main/res/values/strings.xml
+++ b/aFWall/src/main/res/values/strings.xml
@@ -28,6 +28,11 @@
     <string name="dnsproxy_item">(DNS proxy) - DNS lookups via netd</string>
     <string name="ntp_item">(NTP) - Internet time servers</string>
     <string name="root_item">(root) - Applications running as root</string>
+    <string name="adb_item">ADB (Android Debug Bridge)</string>
+    <string name="media_item">Media server</string>
+    <string name="vpn_item">VPN networking</string>
+    <string name="gps_item">GPS</string>
+    <string name="shell_item">Linux shell</string>
     <!-- <string name="operation_timeout">Operation timed out</string> -->
     <string name="fw_enabled">Enable Firewall</string>
     <string name="fw_disabled">Disable Firewall</string>


### PR DESCRIPTION
Currently only six of the special Android accounts are supported:  root, adb, media, vpn, gps, and shell.  This series adds support for all of the (current) special Android accounts (as listed in [the Android source code](https://android.googlesource.com/platform/system/core.git/+/master/include/private/android_filesystem_config.h)), and does some code cleanup.