### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,17 +2,32 @@
 *.apk
 *.ap_
 
-# files for the dex VM
+# Files for the dex VM
 *.dex
 
 # Java class files
 *.class
 
-# generated files
+# Auto generated files
 bin/
 gen/
 out/
 build/
+build.xml
+
+# Gradle wrapper
+gradlew
+gradlew.bat
+gradle-wrapper.jar
+gradle-wrapper.properties
+
+# Gradle
+.gradle/
+gradle/
+gradle*
+
+# Log Files
+*.log
 
 # Local configuration file (sdk path, etc)
 local.properties
@@ -20,11 +35,20 @@ local.properties
 # Eclipse project files
 .classpath
 .project
+proguard/
+
+# Editor swap/save files
+*~
+*.swp
 
 # native binaries
 libs/
 obj/
-.gradle/
-gradle/
-gradle*
+
+# IDE related 
 .idea/
+*.iml
+.settings/
+
+# Proguard 
+proguard-project.txt


### PR DESCRIPTION
The following is deprecated and not necessary for public repos, since Android Studio/Eclipse will override or automatic generate them (per-user specific settings, please read the Android Studio instruction settings):

.gradle 
.idea
gradle