### PR TITLE
Update about.html

### DIFF
--- a/aFWall/src/main/res/raw/about.html
+++ b/aFWall/src/main/res/raw/about.html
@@ -1,8 +1,10 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-<title>About</title>
-<style type="text/css">
+<!doctype html>
+<html>
+   <head>
+      <meta charset="utf-8">
+      <meta http-equiv="X-UA-Compatible" content="chrome=1">
+	  <title>About</title>
+	  <style type="text/css">
 
 body {background:#000; width:100%}
 a {color:#40FF00;}
@@ -30,10 +32,14 @@ div.block .span{
 span.title { padding: 10px 0; }
 
 </style>
-</head>
-<body>
+   </head>
+   <body>
 
-<span style="color: #FFF"><i>AFWall+ aka Android Firewall+</i> is a front-end application for the powerful iptables Linux firewall.
+ <div class="block">
+<label><strong><u>Description</u></strong></label> 
+</div>
+<br>
+<span style="color: #FFF"><i>AFWall+ alias Android Firewall+</i> is a front-end application for the powerful iptables Linux firewall.
 	It allows you to restrict which applications are permitted to access your data networks.
 	This is the perfect solution if you don't have an unlimited data plan, or just want extend battery life.
 </span>
@@ -41,64 +47,82 @@ span.title { padding: 10px 0; }
 <br/><br/>
 
 <div class="block">
- <label><strong>Source Code</strong></label> 
+ <label><strong><u>Source Code</u></strong></label> 
 </div>
+<br>
 <div class="block">
-  <a href="http://github.com/ukanth/afwall">GitHub Page</a>
+	<a href="http://github.com/ukanth/afwall" style="text-decoration:none;">GitHub Page</a></p>
 </div>
 <br/><br/>
 
 <div class="block">
-	<label><strong>Source Code</strong></label>
+	<label><strong><u>Wiki</u></strong></label>
 </div>
+<br>
 <div class="block">
-	<a href="https://github.com/ukanth/afwall/wiki/">FAQ</a>
+	<a href="https://github.com/ukanth/afwall/wiki/FAQ" style="text-decoration:none;">FAQ</a></p>
 </div>
 <br/><br/>
 
 
 <div class="block">
- <label><strong>Licensed Under</strong></label> 
+ <label><strong><u>License</u></strong></label> 
 </div>
+<br>
+<div class="block">
+	<a href="https://www.gnu.org/licenses/gpl.html" style="text-decoration:none;">GNU General Public License v3.0 License</a></p>
+</div>
+
+<br/>
+<br/>
 
 <div class="block">
-  <a href="https://www.gnu.org/licenses/gpl.html">GNU General Public License v3.0 License</a>
+  <label><strong><u>Developers</u></strong></label> 
 </div>
-
-<br/><br/>
-
-<div class="block">
-  <label><strong>Developers</strong></label> 
-</div>
+<br>
 <div class="block">
   <span>Umakanthan Chandan</span> 
-  <a href="mailto:cumakt@gmail.com">Contact</a>
+  <a href="mailto:cumakt@gmail.com">Contact eMail</a>
 </div>
+<br>
 <div class="block">
   <span>Kevin Cernekee</span> 
-  <a href="mailto:cernekee@gmail.com">Contact</a>
+  <a href="mailto:cernekee@gmail.com">Contact eMail</a>
 </div>
 <br>
 <br>
 
+
 <div class="block">
-  <label><strong>Credits</strong></label> 
+  <label><strong><u>Credits</u></strong></label> 
+</div>
+<br>
+<div class="block">
+	<a href="https://github.com/pragma-/networklog" style="text-decoration:none;">Pragma</a> (Networklog) </p>
 </div>
 <div class="block">
-	<a href="https://github.com/pragma-/networklog">Pragma</a> (Networklog)
-</div>
-<div class="block">
-	<a href="https://code.google.com/p/droidwall/">Rodrigo Rosauro</a> (DroidWall)
-</div>
-<div class="block">
-  <a href="http://pdts.net">PdtS</a> (Icons)
-  <a href="http://werewolfdev.deviantart.com/">werewolfdev</a> (Icons)
+	<a href="https://code.google.com/p/droidwall/" style="text-decoration:none;">Rodrigo Rosauro</a> (DroidWall) </p>
 </div>
 <br>
 <br>
 
+
 <div class="block">
- <label><strong>Translators</strong></label> 
+  <label><strong><u>Icons</u></strong></label> 
+</div>
+<br>
+<div class="block">
+	<a href="http://pdts.net" style="text-decoration:none;">PdtS</a></p>
+</div>
+<div class="block">
+	<a href="http://werewolfdev.deviantart.com/" style="text-decoration:none;">werewolfdev</a></p>
+</div>
+<br>
+<br>
+
+
+<div class="block">
+ <label><strong><u>Translators</u></strong></label> 
 </div>
 
 <br>
@@ -124,7 +148,6 @@ span.title { padding: 10px 0; }
 	<tr><td>Swedish</td><td>CreepyLinguist @crowdin</td></tr>
 	<tr><td>Turkish</td><td>BahadirDemirel, myasa, ozgurahmet95 @crowdin</td></tr>
 	<tr><td>Ukrainian</td><td>andriykopanytsia @crowdin</td></tr>
-
 	<tr><td>Basque</td><td>Osoitz @crowdin</td></tr>
 	<tr><td>Arabic</td><td>alruwaile1234  @crowdin</td></tr>
 	<tr><td>Persian</td><td>alruwaile1234  @crowdin</td></tr>
@@ -134,22 +157,69 @@ span.title { padding: 10px 0; }
 
 </table>
 
-<br>
-
-<div class="block">
- <label><strong>3rd Party Libraries</strong></label> 
-</div>
 
 <br>
 
-<table style="color:white">
-	<tr><td><a href="https://github.com/attenzione/android-ColorPickerPreference">Android Color Picker</a></td><td>Apache License 2.0</td></tr>
-	<tr><td><a href="http://www.busybox.net/">Busybox</a></td><td>GNU GPLv2</td></tr>
-	<tr><td><a href="https://github.com/VanirAOSP/external_klogripper">external_klogripper</a></td><td>Apache License 2.0</td></tr>
-	<tr><td><a href="http://netfilter.org/projects/iptables/index.html">IPtables</a></td><td>GNU GPLv2</td></tr>
-	<tr><td><a href="https://github.com/Chainfire/libsuperuser">Libsuperuser</a></td><td>Apache License 2.0</td></tr>
-	<tr><td><a href="http://www.twofortyfouram.com">Locale Plugin</a></td><td>Apache License 2.0</td></tr>
-	<tr><td><a href="https://github.com/Stericson/RootTools">Root Tools</a></td><td>Apache License 2.0</td></tr>
+<!-- Css stuff for the table -->
+<style type="text/css" scoped>
+table.GeneratedTable {
+width:100%;
+background-color:#000000;
+border-collapse:collapse;border-width:1px;
+border-color:#336600;
+border-style:solid;
+color:#FFFFFF;
+}
+
+table.GeneratedTable td, table.GeneratedTable th {
+border-width:1px;
+border-color:#336600;
+border-style:solid;
+padding:3px;
+}
+
+table.GeneratedTable thead {
+background-color:#000000;
+}
+</style>
+
+<!-- Table 7x2 -->
+<table class="GeneratedTable">
+<thead>
+<tr>
+<th>Used Third-Party Libraries</th>
+<th>License</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><tr><td><a href="https://github.com/attenzione/android-ColorPickerPreference">Android Color Picker</a></td>
+<td>Apache License 2.0</td>
+</tr>
+<tr>
+<tr><td><a href="http://www.busybox.net/">Busybox</a></td>
+<td>GNU GPLv2</td>
+</tr>
+<tr>
+<tr><td><a href="https://github.com/VanirAOSP/external_klogripper">external_klogripper</a></td>
+<td>Apache License 2.0</td>
+</tr>
+<tr>
+<tr><td><a href="http://netfilter.org/projects/iptables/index.html">IPTables</a></td>
+<td>GNU GPLv2</td>
+</tr>
+<tr>
+<tr><td><a href="https://github.com/Chainfire/libsuperuser">Libsuperuser</a></td>
+<td>Apache License 2.0</td>
+</tr>
+<tr>
+<tr><td><a href="http://www.twofortyfouram.com">Locale Plugin</a></td>
+<td>Apache License 2.0</td>
+</tr>
+<tr>
+<tr><td><a href="https://github.com/Stericson/RootTools">Root Tools</a></td>
+<td>Apache License 2.0</td>
+</tr>
+</tbody>
 </table>
-</body>	
 </html>


### PR DESCRIPTION
* Chrome offline view fix
* UTF-8 will be used always
* Underline the topics
* Removed some underlined links, only email and external stuff should be underlined
* New table for "Third-Party Libraries" section, padding can be adjusted as per need (see GeneratedTable - padding)
* Removed useless validation