### PR TITLE
Fix error, add missing reference to string

### DIFF
--- a/aFWall/src/main/res/xml/profiles_preferences.xml
+++ b/aFWall/src/main/res/xml/profiles_preferences.xml
@@ -11,13 +11,13 @@
             android:title="@string/multi_apply_rules" />
         <Preference android:title="@string/manage_profiles"
             android:key="manage_profiles"
-            android:summary="@string/manage_profiles"/>
+            android:summary="@string/manage_profiles_summary"/>
         <EditTextPreference
             android:dependency="enableMultiProfile"
             android:key="default"
             android:summary="@string/custom_title1"
             android:title="@string/defaultProfile" />
-     ] <EditTextPreference
+       <EditTextPreference
             android:dependency="enableMultiProfile"
             android:key="profile1"
             android:summary="@string/custom_title2"


### PR DESCRIPTION
There was an extra end-square-bracket in the code.  Removed it.

A reference to the summary string for UI element was missing.  Added it.
