### PR TITLE
Enable IPv6 support by default

### DIFF
--- a/aFWall/src/main/res/xml/rules_preferences.xml
+++ b/aFWall/src/main/res/xml/rules_preferences.xml
@@ -35,7 +35,7 @@
             android:summary="@string/block_ipv6_summary"
             android:title="@string/block_ipv6_title" />
         <CheckBoxPreference
-            android:defaultValue="false"
+            android:defaultValue="true"
             android:key="enableIPv6"
             android:summary="@string/ipv6_summary"
             android:title="@string/ipv6_title" />


### PR DESCRIPTION
IPv6 is now commonplace.  Does the benefit of enabling this outweigh the downside of keeping it disabled by default?  If so, this patch will enable it by default.