### PR TITLE
Split up iptables(8) options in init script.

### DIFF
--- a/aFWall/src/main/res/raw/afwallstart
+++ b/aFWall/src/main/res/raw/afwallstart
@@ -29,9 +29,9 @@ doit() {
   do
     if [ -x "$i" ]
     then
-      "$i" -wP INPUT DROP
-      "$i" -wP OUTPUT DROP
-      "$i" -wP FORWARD DROP
+      "$i" -w -P INPUT DROP
+      "$i" -w -P OUTPUT DROP
+      "$i" -w -P FORWARD DROP
       return
     fi
   done


### PR DESCRIPTION
Split up the 'w' and 'P' options passed to the iptables binaries
in our init script, otherwise the programs try to interpret 'P'
as a timeout value for 'w'.

Signed-off-by: Cal Peake <cp@absolutedigital.net>