### PR TITLE
Potential fix for issue #709

### DIFF
--- a/aFWall/src/main/AndroidManifest.xml
+++ b/aFWall/src/main/AndroidManifest.xml
@@ -203,12 +203,6 @@
                 <data android:scheme="package" />
             </intent-filter>
         </receiver>
-        <receiver android:name=".broadcast.ConnectivityChangeReceiver">
-            <intent-filter>
-                <action android:name="android.net.conn.CONNECTIVITY_CHANGE" />
-                <action android:name="android.net.wifi.WIFI_AP_STATE_CHANGED" />
-            </intent-filter>
-        </receiver>
         <receiver
             android:name=".widget.StatusWidget"
             android:icon="@drawable/preview_toggle"
@@ -307,6 +301,7 @@
 
         <service android:name=".service.RootShellService" />
         <service android:name=".service.LogService" />
+	<service android:name=".service.ConnectivityChangeService" />
 
         <!-- Samsung MultiWindow Support -->
         <uses-library

--- a/aFWall/src/main/java/dev/ukanth/ufirewall/broadcast/ConnectivityChangeReceiver.java
+++ b/aFWall/src/main/java/dev/ukanth/ufirewall/broadcast/ConnectivityChangeReceiver.java
@@ -41,28 +41,25 @@ public class ConnectivityChangeReceiver extends BroadcastReceiver {
     public static final String EXTRA_WIFI_AP_STATE = "wifi_state";
     public static final String EXTRA_PREVIOUS_WIFI_AP_STATE = "previous_wifi_state";
 
-	/*public static final int WIFI_AP_STATE_DISABLING = 10;
+/*
+    public static final int WIFI_AP_STATE_DISABLING = 10;
     public static final int WIFI_AP_STATE_DISABLED = 11;
-	public static final int WIFI_AP_STATE_ENABLING = 12;
-	public static final int WIFI_AP_STATE_ENABLED = 13;
-	public static final int WIFI_AP_STATE_FAILED = 14;*/
+    public static final int WIFI_AP_STATE_ENABLING = 12;
+    public static final int WIFI_AP_STATE_ENABLED = 13;
+    public static final int WIFI_AP_STATE_FAILED = 14;
+*/
 
     @Override
     public void onReceive(final Context context, Intent intent) {
+        // NOTE: this gets called for wifi/3G/tether/roam changes but not VPN connect/disconnect
+        // This will prevent applying rules when the user disable the option in preferences. This is for low end devices
+
         if (intent.getAction().equals(WIFI_AP_STATE_CHANGED_ACTION)) {
             int newState = intent.getIntExtra(EXTRA_WIFI_AP_STATE, -1);
             int oldState = intent.getIntExtra(EXTRA_PREVIOUS_WIFI_AP_STATE, -1);
             Log.d(TAG, "OS reported AP state change: " + oldState + " -> " + newState);
         }
-        // NOTE: this gets called for wifi/3G/tether/roam changes but not VPN connect/disconnect
-        // This will prevent applying rules when the user disable the option in preferences. This is for low end devices
-        if (intent.getAction().equals(WIFI_AP_STATE_CHANGED_ACTION)) {
-            int newState = intent.getIntExtra(EXTRA_WIFI_AP_STATE, -1);
-            int oldState = intent.getIntExtra(EXTRA_PREVIOUS_WIFI_AP_STATE, -1);
-            Log.d(TAG, "OS reported AP state change: " + oldState + " -> " + newState);
-        }
-        // NOTE: this gets called for wifi/3G/tether/roam changes but not VPN connect/disconnect
-        // This will prevent applying rules when the user disable the option in preferences. This is for low end devices
+
         if (Api.isEnabled(context)) {
             if (G.activeRules()) {
                 InterfaceTracker.applyRulesOnChange(context, InterfaceTracker.CONNECTIVITY_CHANGE);

--- a/aFWall/src/main/java/dev/ukanth/ufirewall/service/ConnectivityChangeService.java
+++ b/aFWall/src/main/java/dev/ukanth/ufirewall/service/ConnectivityChangeService.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2017  Calvin E. Peake, Jr. <cp@absolutedigital.net>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package dev.ukanth.ufirewall.service;
+
+import android.app.Service;
+import android.content.BroadcastReceiver;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.os.IBinder;
+
+import dev.ukanth.ufirewall.broadcast.ConnectivityChangeReceiver;
+
+/**
+ * Implements a service to monitor for network connectivity changes
+ * by way of a system broadcast receiver.
+ *
+ * This is necessary as of Android 7.0 (API level 24) as declaring
+ * a broadcast receiver in the app manifest is no longer sufficient
+ * to receive the CONNECTIVITY_ACTION broadcast.
+ *
+ * @see https://developer.android.com/reference/android/net/ConnectivityManager.html#CONNECTIVITY_ACTION
+ * @author Cal Peake
+ */
+public class ConnectivityChangeService extends Service {
+	private BroadcastReceiver receiver;
+	private IntentFilter filter;
+
+	@Override
+	public IBinder onBind(Intent intent) {
+		return null;
+	}
+
+	@Override
+	public void onCreate() {
+		this.receiver = new ConnectivityChangeReceiver();
+		this.filter = new IntentFilter();
+		this.filter.addAction("android.net.conn.CONNECTIVITY_CHANGE");
+		this.filter.addAction("android.net.wifi.WIFI_AP_STATE_CHANGED");
+		this.registerReceiver(this.receiver, this.filter);
+	}
+
+	@Override
+	public void onDestroy() {
+		this.unregisterReceiver(this.receiver);
+	}
+}

--- a/aFWall/src/main/java/dev/ukanth/ufirewall/util/G.java
+++ b/aFWall/src/main/java/dev/ukanth/ufirewall/util/G.java
@@ -24,6 +24,7 @@
 package dev.ukanth.ufirewall.util;
 
 import android.content.Context;
+import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
@@ -46,6 +47,7 @@ import dev.ukanth.ufirewall.Api;
 import dev.ukanth.ufirewall.BuildConfig;
 import dev.ukanth.ufirewall.InterfaceTracker;
 import dev.ukanth.ufirewall.log.Log;
+import dev.ukanth.ufirewall.service.ConnectivityChangeService;
 
 public class G extends android.app.Application {
 
@@ -604,6 +606,7 @@ public class G extends android.app.Application {
                 .openDatabasesOnInit(true).build());
         ctx = this.getApplicationContext();
         reloadPrefs();
+        startService(new Intent(this, ConnectivityChangeService.class));
     }
 
     public static void reloadPrefs() {


### PR DESCRIPTION
ukanth,

After much investigating and debugging of my data leak problem, it looks like it's caused by a change in Android 7.x.  Network connectivity change broadcasts now need a broadcast receiver created in code, declaring a receiver in the manifest no longer works.  See [https://developer.android.com/reference/android/net/ConnectivityManager.html#CONNECTIVITY_ACTION](url).

My fix does this with a service, although I'm not 100% sure if we really need one dedicated just to this.  Please have a look.  This pull also includes a small bit of code cleanup in a related file.

Thanks, -Cal