### PR TITLE
Fix #786

### DIFF
--- a/aFWall/src/main/java/dev/ukanth/ufirewall/preferences/RulesPreferenceFragment.java
+++ b/aFWall/src/main/java/dev/ukanth/ufirewall/preferences/RulesPreferenceFragment.java
@@ -1,12 +1,15 @@
 package dev.ukanth.ufirewall.preferences;
 
+import android.app.Activity;
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.os.Build;
 import android.os.Bundle;
 import android.preference.CheckBoxPreference;
 import android.preference.Preference;
 import android.preference.PreferenceFragment;
 import android.preference.SwitchPreference;
+import android.util.Log;
 
 import java.io.File;
 import java.util.regex.Matcher;
@@ -25,6 +28,7 @@ public class RulesPreferenceFragment extends PreferenceFragment implements
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
+        Log.e("RulesPreferenceFragment", "onCreate");
         super.onCreate(savedInstanceState);
         // Load the preferences from an XML resource
         addPreferencesFromResource(R.xml.rules_preferences);
@@ -129,6 +133,13 @@ public class RulesPreferenceFragment extends PreferenceFragment implements
         ctx = context;
     }
 
+    @Override
+    public void onAttach(Activity activity) {
+        super.onAttach(activity);
+        if(Build.VERSION.SDK_INT < Build.VERSION_CODES.M){
+            ctx = activity;
+        }
+    }
 
     @Override
     public void onResume() {

--- a/aFWall/src/main/java/dev/ukanth/ufirewall/preferences/RulesPreferenceFragment.java
+++ b/aFWall/src/main/java/dev/ukanth/ufirewall/preferences/RulesPreferenceFragment.java
@@ -9,7 +9,6 @@ import android.preference.CheckBoxPreference;
 import android.preference.Preference;
 import android.preference.PreferenceFragment;
 import android.preference.SwitchPreference;
-import android.util.Log;
 
 import java.io.File;
 import java.util.regex.Matcher;
@@ -28,7 +27,6 @@ public class RulesPreferenceFragment extends PreferenceFragment implements
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
-        Log.e("RulesPreferenceFragment", "onCreate");
         super.onCreate(savedInstanceState);
         // Load the preferences from an XML resource
         addPreferencesFromResource(R.xml.rules_preferences);


### PR DESCRIPTION
Fix #786 , now object ‘ctx’ will not be null any more. I found that we may need much effort on changing “`android.preference.PreferenceFragment`” to “`android.support.v7.PreferenceFragmentCompat`”, here is a simpler way to fix the issue.

We add deprecated function ‘`onAttach(Activity)`’ back, since it is guarantee to execute in all version. In API level 23 or above, ‘`onAttach(Activity)`’ will execute in ’`super.onAttach(Context)`’, so we check API level to make sure ‘`onAttach`’ will always execute and execute only once.

To test (My emulator did not root):
1. Create an emulator with API level 22 or below.
2. Choose “Preference”
3. Choose “Rules/Connectivity”
4. Before this fix, the new Fragement open normally without any hints.
5. After this fix, the new Fragment open normally with a toast “error applying iptables rules”.