### PR TITLE
Fix Magisk init.d support: use real path instead of symlink due to ch…

### DIFF
--- a/aFWall/src/main/java/dev/ukanth/ufirewall/preferences/ExpPreferenceFragment.java
+++ b/aFWall/src/main/java/dev/ukanth/ufirewall/preferences/ExpPreferenceFragment.java
@@ -30,7 +30,7 @@ import static dev.ukanth.ufirewall.Api.mountDir;
 public class ExpPreferenceFragment extends PreferenceFragment implements
         OnSharedPreferenceChangeListener {
 
-    private final String initDirs[] = {"/magisk/.core/service.d", "/magisk/phh/su.d", "/su/su.d", "/system/su.d", "/system/etc/init.d", "/etc/init.d"};
+    private final String initDirs[] = {"/magisk/.core/service.d", "/sbin/.core/img/.core/service.d", "/magisk/phh/su.d", "/sbin/.core/img/phh/su.d", "/su/su.d", "/system/su.d", "/system/etc/init.d", "/etc/init.d"};
     private final String initScript = "afwallstart";
 
     @SuppressLint("NewApi")


### PR DESCRIPTION
In Magisk 16.3 and above the symlink "/magisk -> /sbin/.core/img" got removed.
This replaces the symlink with the real path so the "fix startup data leak" feature in aFWall works with newer Magisk installations.
