### PR TITLE
Updated Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,17 @@
 ## AFWall+ (Android Firewall+) [![Build Status](https://travis-ci.org/ukanth/afwall.png?branch=beta)](https://travis-ci.org/ukanth/afwall) [![Crowdin](https://d322cqt584bo4o.cloudfront.net/afwall/localized.png)](https://crowdin.net/project/afwall)
-[![Donate](https://www.paypalobjects.com/en_US/i/btn/btn_donate_LG.gif)](https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=6E4VZTULRB8GU)
-======
 
-![AFwall+](https://raw.githubusercontent.com/ukanth/afwall/0502e6f17ceda08069720ff2f260902690e65e9b/screenshots/Main_2.0.png)
+Description
+-----------
 
-[![Google Play](https://play.google.com/intl/en_us/badges/images/badge_new.png)](https://play.google.com/store/apps/details?id=dev.ukanth.ufirewall)
+Android Firewall+ (AFWall+) is an advanced iptables editor (GUI) for Android. It provides fine-grained control over which Android apps are allowed to access the network.
+
+For more information and a community discussion ground, please visit the official [XDA thread](http://forum.xda-developers.com/showthread.php?t=1957231) or the official [Wiki page](https://github.com/ukanth/afwall/wiki).
+
+
+<img src="https://raw.githubusercontent.com/ukanth/afwall/0502e6f17ceda08069720ff2f260902690e65e9b/screenshots/Main_2.0.png" width="300">
+
+
+[![Google Play](https://play.google.com/intl/en_us/badges/images/badge_new.png)](https://play.google.com/store/apps/details?id=dev.ukanth.ufirewall) 
 
 Index
 -----
@@ -19,35 +26,30 @@ Index
 * [Compatibility](#compatibility)
 * [Upgrading](#upgrading)
 * [Permissions](#permissions)
-* [Frequently Asked Questions (FAQ)](#frequently-asked-questions-FAQ)
+* [Frequently Asked Questions (FAQ)](#frequently-asked-questions)
 * [License](#license)
 * [Acknowledgements](#acknowledgements)
-* [Compile AFWall+](#compile-afwall)
+* [Compiling AFWall+](#compiling-the-apk)
 * [Compile Native Binaries](#compiling-native-binaries)
 * [Contributing](#contributing)
 * [Translating](#translating)
+* [Donations](#donations)
 
-Description
------------
-
-Android Firewall+ (AFWall+) is an advanced iptables editor (GUI) for Android. It provides fine-grained control over which Android apps are allowed to access the network.
-
-For more information and community discussions, please visit the [XDA thread](http://forum.xda-developers.com/showthread.php?t=1957231) or [our Wiki](https://github.com/ukanth/afwall/wiki).
 
 Availability
 ------------
-Download the latest release from the [Google Play Store](https://play.google.com/store/apps/details?id=dev.ukanth.ufirewall), [GitHub](https://github.com/ukanth/afwall/releases), or [F-Droid](https://f-droid.org/repository/browse/?fdid=dev.ukanth.ufirewall)
+AFWall can be downloaded via [Google Play Store](https://play.google.com/store/apps/details?id=dev.ukanth.ufirewall), [GitHub](https://github.com/ukanth/afwall/releases) or via [F-Droid](https://f-droid.org/repository/browse/?fdid=dev.ukanth.ufirewall).
 
-The [changelog](https://github.com/ukanth/afwall/blob/beta/Changelog.md) documents changes between each release.
+The [changelog](https://github.com/ukanth/afwall/blob/beta/Changelog.md) documents changes between each new release.
 
 Supports
 --------
 * Android versions 5.x to 9.x
     for 4.x - 2.9.9 
     for 2.x - 1.3.4.1
-* Compatible with Magisk and Lineage su.    
+* Compatible with Magisk and LineageOS su.    
 * ARM/MIPS/x86 processors
-* IPv4 and IPv6 protocols
+* IPv4 & IPv6 protocols
 * WiFi, mobile data, LAN, VPN, tether, roaming and Tor
 * Multi-user (multiple profiles)
 * Many languages *(see [Translating](#translating))*
@@ -58,29 +60,30 @@ Highlights
 ----------
 * Easy to install
 * Simple to use
-* Free and open source
+* Free & open source
 * No advertisements
-* Built-in iptables/BusyBox
+* Built-in IPtables/BusyBox
 
 Features
 --------
-* Search for installed applications
-* Sort installed applications by installed date/UID/alphabatical order
-* Receive notification for any newly installed application with internet permission
-* Firewall logs service
-* Optionally display notifcations for blocked packets
+* List and search for all installed applications
+* Sort installed applications by installation date, [UUID](https://developer.android.com/reference/java/util/UUID) or in alphabatical order
+* Receive notification for any newly installed application, AFwall only list app with INTERNET_PERMISSION
+* AFWall comes with it's logs service to see what's going on
+* Display notifcations for blocked packets
 * Filter blocked packet notifications per app
-* Export and import rules (Import All Rules requires donate version)
+* Export & import rules ("Import All Rules" requires the donate version)
 * Option to prevent data leaks during boot (requires *init.d* support or *S-OFF*)
-* Optional Password protection
-* Option to manage rules with a custom script
-* ~~Option to enable Device Admin to protect AFWall+ from uninstall~~
+* Password protection
+* Option to manage iptable rules with a custom script
+* ~~Device Admin to protect AFWall+ from uninstall~~ (see [here](https://developers.google.com/android/work/device-admin-deprecation) why it was removed)
 
 Bug Reports
 -----------
 
-Please see the [issues](https://github.com/ukanth/afwall/issues) section to
-report any bugs, make feature requests, and to see the list of known issues. Before you report a bug, take a look [here](https://github.com/ukanth/afwall/wiki/HOWTO-Report-Bug).
+Please check GitHub's [issues](https://github.com/ukanth/afwall/issues) section for existing bugs and in case you like to submit a new one. Feature requests are also welcome. 
+
+Before you report any problem/bug, take a look into the [how-to-report a bug](https://github.com/ukanth/afwall/wiki/HOWTO-Report-Bug) section.
 
 Limitations
 -----------
@@ -88,39 +91,43 @@ Limitations
 * A firewall cannot protect against attacks that are performed outside the operating point. For example, if there is a Point-to-Point connection to the Internet.
 * A firewall cannot prevent corporate data from being copied to a memory stick or HDD, and having these removed from the building. 
 * AFWall+ does not scan for virus/malware that may exist in the files that pass through it, because it is a firewall and not an antivirus solution.
+* AFWall+ is not an ad-blocker.
+* Some apps/script which are running under admin rights might bypassing AFWall because they overwrite the system own IPtables with their own rules. Make sure you only give trusted application superuser rights, most "su"-solutions have companion apps which showing which apps are running under which rights like MagisK, Chainfire's su etc.
 
 Compatibility
 -------------
 
-AFWall+ has been successfully tested with Android versions 4.x - 7.x. (ICS, JellyBean, KitKat, Lollipop, Marshmallow, Nougat) and is reported to work with most Android variants, including stock ROMs.
+AFWall+ has been successfully tested under Android versions 4.x - 9.x. and is reported to work with most Android variants, including stock or exotic ROMs.
 
-We do not recommend using AFWall+ in combination with any of the similar solutions because this could result in conflicts and potential data leaks (iptables could get overwritten).
+We do not recommend using AFWall+ in combination with any of the similar solutions (Avast, Kaspersky, NetGuard etc) because this could result in conflicts or even data leaks (e.g. IPtables could get overwritten).
 
 Upgrading
 ---------
 
-* **Make a backup of the current version** (e.g. using Titanium Backup).
-* **Do not remove the current version** (otherwise your settings might get reset).
-* Download the new version.
+The upgrading mechanism is really simple, basically you can just "over-install" the new version over the old one, however this is the best pratice (which we recommended):
+
+* **Make a backup of the current version** (e.g. via Titanium Backup).
+* **Do not remove the current version** (otherwise your settings might getting reset).
+* Download the latest AFWall+ version.
 * Install the new version over the previous version.
 * Done!
 
 Permissions
 -----------
 
-AFWall+ asks for the following Android permissions:
+AFWall+ asks for the following [Android permissions](https://developer.android.com/guide/topics/permissions/overview):
 
 * RECEIVE_BOOT_COMPLETED: Autostart (Bootup) AFWall+ after the system finishes booting.
 * ACCESS_NETWORK_STATE: Allows AFWall+ to access information about networks (iptables).
 * WRITE_EXTERNAL_STORAGE: Allows AFWall+ to write to external storage for debug log and export iptables rules.
-* DEPRECATED ~~ACCESS_SUPERUSER: Standard to support Superuser/SuperSU (by Koushik/Chainfire)~~
 * INTERNET: NetworkInterface.getNetworkInterfaces() needs android.permission.INTERNET. This is just being used to get the IPv4 and IPv6 addresses/subnets for each interface, so the LAN address ranges can be determined. Nothing is actually trying to access the network. Also take a look at [Stackoverflow](https://stackoverflow.com/questions/17252018/getting-my-lan-ip-address-192-168-xxxx-ipv4).
 * ACCESS_WIFI_STATE: Used to detect the tether state.
+* DEPRECATED ~~ACCESS_SUPERUSER: Standard to support Superuser/SuperSU (by Koushik/Chainfire)~~
 
-Frequently Asked Questions (FAQ)
---------------------------------
+Frequently Asked Questions
+-----------
 
-Having problems with AFWall+? Check out our [FAQ](https://github.com/ukanth/afwall/wiki/FAQ) before reporting a bug or problem that may already be known.
+Having some problems with AFWall+? Check out our [FAQ](https://github.com/ukanth/afwall/wiki/FAQ) before reporting a bug or problem that may already be known or answered.
 
 License
 -------
@@ -132,7 +139,7 @@ Acknowledgements
 
 The original codebase was derived from [DroidWall](http://code.google.com/p/droidwall) by Rodrigo Rosauro. DroidWall was sold to AVAST in December 2011, and is no longer actively maintained.
 
-This project also uses many other open-source libraries such as:
+This project also uses some other open-source libraries such as:
 
 <table>
     <tr>
@@ -192,14 +199,14 @@ This project also uses many other open-source libraries such as:
     </tr>	
 </table>
 
-Compile AFWall+
+Compiling the APK
 ---------------
 
 Prerequisites:
 
 * Android SDK in your $PATH (both platform-tools/ and tools/ directories)
 * Javac 1.7 (or higher) and a recent version of Apache ant in your $PATH
-* Git in your $PATH
+* Git should be added in your $PATH
 * Use the Android SDK Manager to install API 19 (or higher)
 
 Quick start:
@@ -212,7 +219,7 @@ For complete instructions, please take a look at the [Wiki's How To Compile AFWA
 
 ## Compiling Native Binaries
 
-On the host side, you will need to install:
+You can compile the external binaries like BusyBox or the IPtables yourself, on the host side, you'll need to install the following:
 
 * [NDK r10](http://developer.android.com/tools/sdk/ndk/index.html), nominally under /opt/android-ndk-r10
 * Host-side gcc 4.7, make, etc. (Red Hat 'Development Tools' group or Debian build-essential)
@@ -225,12 +232,20 @@ This command will build the Android binaries and copy them into `res/raw/`:
 Contributing
 ------------
 
-Please fork this repository and contribute back using [pull requests](https://github.com/ukanth/afwall/pulls).
+You can fork the repository and contribute using [pull requests](https://github.com/ukanth/afwall/pulls).
 
-All contributions, large or small, major features, bug fixes, additional language translations, unit/integration tests are welcomed and appreciated but will be thoroughly reviewed and discussed.
+All contributions no matter if large or small, major features, bug fixes, additional language translations, unit/integration tests are welcomed and appreciated. The pull requests and findings are usually getting reviewed and discussed with the developer and the community .
 
 Translating
 -----------
-The `res/values-*` dirs are kept up to date automatically via the Crowdin Translate Extension. See [our translation page](http://crowdin.net/project/afwall) if you would like to contribute.
+The `res/values-*` dirs are kept up-to-date automatically via the [Crowdin Translate Extension](https://github.com/marketplace/crowdin). See [our official translation page](http://crowdin.net/project/afwall) in case you like to contribute.
 
-This application is available in many languages, but if yours is not included, or if it needs updating or improving, please create an account and use the translation system (powered by the Crowdin Translate Extension) and make your changes.
+AFWall+ is available in many languages but if yours is not included - or if it needs updating or improving - please create an account and use the translation system and commit your changes.
+
+
+Donations
+-----------
+
+Donations are **optional** and helps the project in order to keep up the development. The official donation link is the one below which points to the official AFWall+ PayPal account. You optionally can buy the unlocker key via Google Play Store which unlocks additional features in AFWall+, the unlocker is not avbl. via F-Droid.
+
+[![Donate](https://www.paypalobjects.com/en_US/i/btn/btn_donate_LG.gif)](https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=6E4VZTULRB8GU)


### PR DESCRIPTION
- Changed the screenshot size to 300px (for those who are currently not behind wifi) 
- Put the "Description" on top of everything (usually most articles follow the same simple rules, like Wikipedia etc.) first text/overview and then the picture (or as thumb, preview etc)
- Donations got his own category (GitHub has also a "support") option which can be activated via the AFWall+ GitHub project settings page. The benefit is that it also lists which people donated to AFWall+, however its limited because you can't use every donation service. It might be something to look into it in the future.
- Mention that some apps/scripts can overwrite the system own IPtables if they are running under su rights. There is not really a good solution because once su is involved there is no "security", unless the user manually approve those apps individually and this is usually done via terminal or companion apps, those are usually been installed once you root your device, or they come as separate download from the same author.
- Some other (small) changes