### PR TITLE
Update BusyBox & iptables to latest binaries

### DIFF
--- a/external/Makefile
+++ b/external/Makefile
@@ -52,7 +52,7 @@ unpack: $(addsuffix -unpack,$(PER_ARCH_TARGETS))
 #
 # Build iptables
 #
-IPTABLES_VER := 1.4.20
+IPTABLES_VER := 1.8.3
 IPTABLES_SRC := sources/iptables-$(IPTABLES_VER)
 IPTABLES_BUILD := $(TRIPLET)/iptables
 
@@ -89,7 +89,7 @@ iptables-unpack: $(IPTABLES_SRC)/configure
 #
 # Build busybox
 #
-BUSYBOX_VER := 1.26.2
+BUSYBOX_VER := 1.31.0
 BUSYBOX_BUILD := $(TRIPLET)/busybox
 
 dist/busybox-$(BUSYBOX_VER).tar.bz2:


### PR DESCRIPTION
- Some patches are obsolete because the source itself got changed (or fixed).
- The /dist dir should be cleaned and updated in order to provide only the useful stuff, some patches (as mentioned) are obsolete.
- According to the iptables or busybox changes (check the official download dir for the changelogs) aren't affecting the current AFWall+ functions however, it might take some work to get the binaries working so that they are fully functional under Android version xyz. 
- I submit all changes to BusyBox and to the netfilters project, I (we) have to wait and see if they finally merge it, if that happens we can compile the binaries direct from the source without anything to worry about. 