### PR TITLE
Fix crash for different app using DownloadManager#enqueue

### DIFF
--- a/aFWall/src/main/java/dev/ukanth/ufirewall/xposed/XposedInit.java
+++ b/aFWall/src/main/java/dev/ukanth/ufirewall/xposed/XposedInit.java
@@ -120,9 +120,11 @@ public class XposedInit implements IXposedHookZygoteInit, IXposedHookLoadPackage
                 final boolean isAppAllowed = Api.isAppAllowed(context, applicationInfo, sharedPreferences, pPrefs);
                 Log.d(TAG, "DM Calling Application: " + applicationInfo.packageName + ", Allowed: " + isAppAllowed);
                 if (!isAppAllowed) {
-                    param.setResult(0);
-                    DownloadManager dm = (DownloadManager) context.getSystemService(Context.DOWNLOAD_SERVICE);
-                    dm.remove(0);
+                    if (param.getResult() != null) {
+                        DownloadManager dm = (DownloadManager) context.getSystemService(Context.DOWNLOAD_SERVICE);
+                        dm.remove((Long) param.getResult());
+                    }
+                    param.setResult(0L);
                     if (getActivity() != null) {
                         getActivity().runOnUiThread(() -> Toast.makeText(getActivity().getApplicationContext(), "AFWall+ denied access to Download Manager for package(uid) : " + applicationInfo.packageName + "(" + applicationInfo.uid + ")", Toast.LENGTH_LONG).show());
                     }


### PR DESCRIPTION
Hi,

I'm the maintainer of [FFUpdater](https://f-droid.org/en/packages/de.marmaro.krt.ffupdater/). A user has reported a bug: when FFUpdater tries to download a file with the android.app.DownloadManager, then the app crashes.

And this command causes the error:
`long id = downloadManager.enqueue(request);` https://notabug.org/Tobiwan/ffupdater/src/master/ffupdater/src/main/java/de/marmaro/krt/ffupdater/download/DownloadManagerAdapter.java#L58

And this is the stacktrace:
```
Caused by: java.lang.ClassCastException: java.lang.Integer cannot be cast to java.lang.Long 
	at SandHookerNew_3cs36rvf3cc996immrm66lah5p.hook(Unknown Source:56) 
	at de.marmaro.krt.ffupdater.download.DownloadManagerAdapter.enqueue(DownloadManagerAdapter.java:61) 
```

`SandHookerNew_3cs36rvf3cc996immrm66lah5p` is generated by the Xposed-Framework when hooking the method: `public long android.app.DownloadManager.enqueue(android.app.DownloadManager$Request)`.

The user has/uses (from https://notabug.org/Tobiwan/ffupdater/issues/24):
 - Samsung Galaxy S10+
 - LineageOS 17.1 (Android 10)
 - Xposed Framework
 - FFUpdater
 - AFWall+

My theorie:
 - android.app.DownloadManager#enqueue is hooked by AFWall+
 - you call `param.setResult(0)`
 - but 0 is an int and will be autoboxed to Integer when storing as Object
 - the Integer (disguised as an Object) is going to be casted to a long (because DownloadManager#enqueue must return a long https://developer.android.com/reference/android/app/DownloadManager#enqueue(android.app.DownloadManager.Request))
 - but this is not possible => ClassCastException

`0` is an int and `0L` is a long.

This following code will also produce a ClassCastException:
```
int i = 10;
Object o = i;
long l = (long) o; //java.lang.ClassCastException: java.lang.Integer cannot be cast to java.lang.Long
```

Please check my fix thoroughly. I have no device with root or Xposed => I can't test it. It's just a lucky guess.

Additional: (As far as I know) calling `dm.remove(0)` is not enought to remove the latest enqueued download - using the id from param should be more reliable.

Can you merge my fixes? I guess that some other apps are also effected by this bug too.