### PR TITLE
Apply custom rules on connection change

### DIFF
--- a/app/src/main/java/dev/ukanth/ufirewall/Api.java
+++ b/app/src/main/java/dev/ukanth/ufirewall/Api.java
@@ -686,6 +686,8 @@ public final class Api {
     private static void applyShortRules(Context ctx, List<String> cmds, boolean ipv6) {
         Log.i(TAG, "Setting OUTPUT chain to DROP");
         cmds.add("-P OUTPUT DROP");
+        Log.i(TAG, "Applying custom rules");
+        addCustomRules(Api.PREF_CUSTOMSCRIPT, cmds);
         addInterfaceRouting(ctx, cmds, ipv6);
         Log.i(TAG, "Setting OUTPUT chain to ACCEPT");
         cmds.add("-P OUTPUT ACCEPT");


### PR DESCRIPTION
Hi @ukanth, this fixes #579. Analysis of the issue:
[InterfaceTracker#applyRules](https://github.com/ukanth/afwall/blob/7a28492eb29de308ed5b75f37c341b2173062e2a/app/src/main/java/dev/ukanth/ufirewall/InterfaceTracker.java#L276) gets called when the (wifi) connection changes. This in turn calls [Api#fastApply](https://github.com/ukanth/afwall/blob/7a28492eb29de308ed5b75f37c341b2173062e2a/app/src/main/java/dev/ukanth/ufirewall/Api.java#L1050).
In there is a test for [`!rulesUpToDate`](https://github.com/ukanth/afwall/blob/7a28492eb29de308ed5b75f37c341b2173062e2a/app/src/main/java/dev/ukanth/ufirewall/Api.java#L1052) which is usually `false` in the case of just a connection change, so in turn [`applyShortRules`](https://github.com/ukanth/afwall/blob/7a28492eb29de308ed5b75f37c341b2173062e2a/app/src/main/java/dev/ukanth/ufirewall/Api.java#L1060) and `iptablesCommands` are executed and add their respective commands to the list. Nowhere [Api#addCustomRules](https://github.com/ukanth/afwall/blob/7a28492eb29de308ed5b75f37c341b2173062e2a/app/src/main/java/dev/ukanth/ufirewall/Api.java#L537) gets called, so the custom rules are ignored in this case.
I then saw that `addCustomRules` is called in [Api#applyIptablesRulesImpl](https://github.com/ukanth/afwall/blob/7a28492eb29de308ed5b75f37c341b2173062e2a/app/src/main/java/dev/ukanth/ufirewall/Api.java#L701) right before `addInterfaceRouting` which is why I put the call in `applyShortRules` just before `addInterfaceRouting`.

If I missed anything or you are not satisfied, let me know and I'll fix it.
Cheers