### PR TITLE
Initial support for Android 11+

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -46,7 +46,12 @@
     <uses-permission android:name="android.permission.USE_BIOMETRIC" />
 
 
+    <!-- This works fine prior to Android version 11 -->
     <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES" tools:ignore="QueryAllPackagesPermission"/>
+
+    <!-- Needed for Android 11+ to correctly interact with apps that have been installed for other users -->
+    <!-- HOWEVER... As this is WIP, AFWall needs to be installed on the system partition to function -->
+    <uses-permission android:name="android.permission.INTERACT_ACROSS_USERS_FULL" tools:ignore="ProtectedPermissions" />
 
     <uses-permission
        android:name="android.permission.FOREGROUND_SERVICE"/>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -51,7 +51,9 @@
 
     <!-- Needed for Android 11+ to correctly interact with apps that have been installed for other users -->
     <!-- HOWEVER... As this is WIP, AFWall needs to be installed on the system partition to function -->
-    <uses-permission android:name="android.permission.INTERACT_ACROSS_USERS_FULL" tools:ignore="ProtectedPermissions" />
+    <uses-permission android:name="android.permission.INTERACT_ACROSS_USERS_FULL" android:protectionLevel="signatureOrSystem" tools:ignore="ProtectedPermissions" />
+    <uses-permission android:name="android.permission.INTERACT_ACROSS_USERS" android:protectionLevel="signatureOrSystem" tools:ignore="ProtectedPermissions" />
+    <uses-permission android:name="android.permission.INTERACT_ACROSS_PROFILES" android:protectionLevel="signatureOrSystem" tools:ignore="ProtectedPermissions" />
 
     <uses-permission
        android:name="android.permission.FOREGROUND_SERVICE"/>


### PR DESCRIPTION
Follow-on from the discussion here https://github.com/ukanth/afwall/issues/1280

This PR provides some initial support for Android 11/12+. This is necessary because of Google's recent permissions changes. The changes prevent afwall from seeing all applications installed for other users. This breaks integration with work profile/parallel space etc.

I'm putting this in as a draft for the time being as I'm still investigating this.