### PR TITLE
[Issue #4] Bug in the implementation of Api.GetApps() leading to users with id 0 getting ignored.

### DIFF
--- a/app/src/main/java/dev/ukanth/ufirewall/Api.java
+++ b/app/src/main/java/dev/ukanth/ufirewall/Api.java
@@ -1422,7 +1422,7 @@ public final class Api {
                 Matcher m = p.matcher(user.toString());
                 if (m.find() && m.groupCount() > 0) {
                     int id = Integer.parseInt(m.group(1));
-                    if (id > 0) {
+                    if (id >= 0) {
                         listOfUids.add(id);
                     }
                 }


### PR DESCRIPTION
Fixed a bug in the implementation of Api.getApps() leading to users with id 0 getting ignored and subsequently to the returned apps list being empty.