### PR TITLE
Fix the text misalignment in RTL mode

### DIFF
--- a/app/src/main/res/layout/customscript.xml
+++ b/app/src/main/res/layout/customscript.xml
@@ -25,9 +25,9 @@
                 android:id="@+id/customscript_link"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:gravity="left"
+                android:gravity="start"
                 android:text="@string/custom_script_info"
-                android:layout_gravity="left" />
+                android:layout_gravity="start" />
 
             <EditText
                 android:id="@+id/customscript"
@@ -57,7 +57,7 @@
             <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:gravity="left"
+                android:gravity="start"
                 android:text="@string/custom_script2_info" />
 
             <EditText

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -83,7 +83,7 @@
     <string name="custom_script_defined">تعريف برنامج نصي مخصص</string>
     <string name="custom_script_removed">إزالة برنامج نصي مخصص</string>
     <string name="custom_script_error">حدث خطأ أثناء حفظ البرنامج النصي المخصص</string>
-    <string name="custom_script_info">&lt;b&gt;أدخل السكريبت المعدل أسفله&lt;/b&gt; \n&gt;i/&gt;(أتركه فارغ لحذفه.)&lt;/i&gt; \nلمعلومات حول السكريبتات المعدلة اضغط  &lt;a href="https://github.com/ukanth/afwall/wiki/CustomScripts"&gt;هنا&lt;/a&gt;.</string>
+    <string name="custom_script_info"><b>أدخل السكريبت المعدل أسفله</b> \n<i>(أتركه فارغ لحذفه.)</i> \nلمعلومات حول السكريبتات المعدلة اضغط  <a href="https://github.com/ukanth/afwall/wiki/CustomScripts">هنا</a>.</string>
     <string name="custom_script2_info">     يمكنك أيضا تعريف \n <b>البرنامج النصي المخصص لإيقاف التشغيل</b> \nYou برنامج نصي مخصص ليتم تنفيذها عندما يكون <b>تعطيل</b> جدار الحماية:</string>
     <string name="unsaved_changes">التغييرات غير محفوظة</string>
     <string name="unsaved_changes_message">لم تقم بتطبيق التغييرات. \n هل تريد تطبيقها أو تجاهلها ؟</string>
@@ -330,6 +330,8 @@
     <string name="showfilter_summary_off">إخفاء التصفية في طريقة العرض الأساسية حسب (الكل\الأساسية\النظام\المستخدم)</string>
     <string name="enable_dns">تمكين DNS عبر netd</string>
     <string name="disable_dns">تعطيل DNS عبر netd</string>
+    <string name="dns_proxy_title">وكيل خدمة أسماء النطاقات DNS</string>
+    <string name="dns_proxy_summary">عمليات البحث عن DNS يتم عبر netd على اندرويد 4.3 وما بعده. سيؤدي تعطيل هذا إلى حظر الإنترنت على تلك الأجهزة.</string>
     <string name="tasker_lable">إضافة مستخدمي المهام AFWall+</string>
     <string name="enable">تمكين</string>
     <string name="disable">تعطيل</string>


### PR DESCRIPTION
Hi,

I found a bug in customscript.xml. The original visual appearance is like this:
![image](https://github.com/user-attachments/assets/ce1fa58c-dfaa-4b9d-a0e9-f980a513252d)
When I change the language to Arabic, the visual appearance looks like this:
![image](https://github.com/user-attachments/assets/485a2770-d841-4d36-8c73-10a4f6260d38)
See, the html element cannot be parsed, and the text is not aligned to the right.
I open the pull request by changing the text in Arabic, and the text alignment from "left" to "start", now the issue has been fixed like this:
<img width="201" alt="image" src="https://github.com/user-attachments/assets/2bd2395e-195c-4cda-bd9f-a0c3b850f71e">

Hope the above information useful