### PR TITLE
Update README to mention support for newer Android versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ The [changelog](https://github.com/ukanth/afwall/blob/beta/Changelog.md) documen
 Supports
 --------
 * Android versions 5.x to 11.x
-    for 4.x - 2.9.9 
-    for 2.x - 1.3.4.1
+   - for Android versions till 4.x use [2.9.9](https://github.com/ukanth/afwall/releases/tag/v2.9.9) 
+   - for Android versions till 2.x use [1.3.4.1](https://github.com/ukanth/afwall/releases/tag/v1.3.4.1)
 * Compatible with Magisk and LineageOS su.    
 * ARM/MIPS/x86 processors
 * IPv4 & IPv6 protocols

--- a/README.md
+++ b/README.md
@@ -69,10 +69,10 @@ Highlights
 Features
 --------
 * List and search for all installed applications
-* Sort installed applications by installation date, [UUID](https://developer.android.com/reference/java/util/UUID) or in alphabatical order
+* Sort installed applications by installation date, [UUID](https://developer.android.com/reference/java/util/UUID) or in alphabetical order
 * Receive notification for any newly installed application, AFwall only list app with INTERNET_PERMISSION
-* AFWall comes with it's logs service to see what's going on
-* Display notifcations for blocked packets
+* AFWall comes with its logs service to see what's going on
+* Display notifications for blocked packets
 * Filter blocked packet notifications per app
 * Export & import rules ("Import All Rules" requires the donate version)
 * Option to prevent data leaks during boot (requires *init.d* support or *S-OFF*)
@@ -106,7 +106,7 @@ We do not recommend using AFWall+ in combination with any of the similar solutio
 Upgrading
 ---------
 
-The upgrading mechanism is really simple, basically you can just "over-install" the new version over the old one, however this is the best pratice (which we recommended):
+The upgrading mechanism is really simple, basically you can just "over-install" the new version over the old one, however this is the best practice (which we recommended):
 
 * **Make a backup of the current version** (e.g. via Titanium Backup).
 * **Do not remove the current version** (otherwise your settings might getting reset).

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The [changelog](https://github.com/ukanth/afwall/blob/beta/Changelog.md) documen
 
 Supports
 --------
-* Android versions 5.x to 11.x
+* Android versions 5.x to 15.x
    - for Android versions till 4.x use [2.9.9](https://github.com/ukanth/afwall/releases/tag/v2.9.9) 
    - for Android versions till 2.x use [1.3.4.1](https://github.com/ukanth/afwall/releases/tag/v1.3.4.1)
 * Compatible with Magisk and LineageOS su.    
@@ -99,7 +99,7 @@ Limitations
 Compatibility
 -------------
 
-AFWall+ has been successfully tested under Android versions 4.x - 9.x. and is reported to work with most Android variants, including stock or exotic ROMs.
+AFWall+ has been successfully tested under Android versions 4.x - 15.x. and is reported to work with most Android variants, including stock or exotic ROMs.
 
 We do not recommend using AFWall+ in combination with any of the similar solutions (Avast, Kaspersky, NetGuard etc) because this could result in conflicts or even data leaks (e.g. IPtables could get overwritten).
 


### PR DESCRIPTION
Hi, when I looked at the repo a few days ago I was afraid that AFWall was not compatible with newer versions of Android, but I have it running on Android 14 and 15 (Samsung S7 with [LineageOS 21.0](https://ivanmeler.github.io/devices/herolte.html) and Pixel 9 Pro with [Lineage OS 22.2](https://download.lineageos.org/devices/caiman/builds) now.

The Pixel, which is my daily driver, has had no problems so far, so I assume the important features are working. But I can test whatever you want. Unfortunately I did not test if there are any issues on the stock rom.

In addition I corrected some typos in the readme and fixed a bulletpoint which I assume wasn't shown correctly and I added links to the mentioned releases (not that anyone will ever need those anymore, but you know..).